### PR TITLE
Potential fix for code scanning alert no. 3: Incomplete URL substring sanitization

### DIFF
--- a/src/octokit.ts
+++ b/src/octokit.ts
@@ -39,8 +39,25 @@ export const createOctokit = (
     });
   };
 
+  const containsTagProtectionSunsetUrl = (message: string): boolean => {
+    const urlMatches = message.match(/https?:\/\/[^\s)]+/g) ?? [];
+
+    return urlMatches.some((value) => {
+      try {
+        const parsed = new URL(value);
+        return (
+          parsed.protocol === 'https:' &&
+          parsed.host === 'gh.io' &&
+          parsed.pathname === '/tag-protection-sunset'
+        );
+      } catch {
+        return false;
+      }
+    });
+  };
+
   const wrappedWarn: LoggerFn = (message: string, meta: unknown) => {
-    if (message.includes('https://gh.io/tag-protection-sunset')) return;
+    if (containsTagProtectionSunsetUrl(message)) return;
     logger.warn(message, meta);
   };
 


### PR DESCRIPTION
Potential fix for [https://github.com/scottluskcis/octokit-harness/security/code-scanning/3](https://github.com/scottluskcis/octokit-harness/security/code-scanning/3)

Use URL parsing and exact host/path matching instead of substring matching.

Best fix in `src/octokit.ts`:
- Add a small helper that extracts URLs from a message, parses each with `new URL(...)`, and returns true only when one matches the expected destination (`host === 'gh.io'` and `pathname === '/tag-protection-sunset'`).
- Replace the line-43 `includes(...)` check with this helper.
- Keep behavior unchanged otherwise (still suppresses that specific warning), but remove accidental matches where the substring appears in unrelated text/URLs.

No new dependency is required; use built-in `URL`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
