### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/verify-package.yml
+++ b/.github/workflows/verify-package.yml
@@ -7,6 +7,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   verify:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/scottluskcis/octokit-harness/security/code-scanning/5](https://github.com/scottluskcis/octokit-harness/security/code-scanning/5)

Add an explicit top-level `permissions` block to `.github/workflows/verify-package.yml` so the workflow token is constrained by default.  
Best fix without changing behavior: set:

- `contents: read`

at workflow root (between `on:` section and `jobs:` is conventional). This is sufficient for `actions/checkout` and other read-only build steps in this workflow. No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
