### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [created]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/scottluskcis/octokit-harness/security/code-scanning/4](https://github.com/scottluskcis/octokit-harness/security/code-scanning/4)

Add an explicit `permissions` block so the workflow does not rely on repository/org defaults. The best non-breaking approach is:

- Define a **workflow-level** minimal permission:
  - `contents: read`
- Keep the existing **job-level** override for `publish-gpr`:
  - `packages: write`
  - `contents: read`

This preserves current functionality:
- `build` gets only read access to contents (sufficient for checkout/build/test).
- `publish-gpr` retains required package publish capability.

Change location:
- File: `.github/workflows/release-package.yml`
- Insert `permissions:` block after the `on:` trigger section and before `jobs:`.

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
